### PR TITLE
Fixes for watson-developer-cloud SDK 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv==0.8.2
 Flask
-watson_developer_cloud==1.5
+watson_developer_cloud==2.0

--- a/welcome.py
+++ b/welcome.py
@@ -58,7 +58,7 @@ def classify_text():
     classifier_info = json.dumps(CLASSIFIER, indent=4)
     # send the text to the classifier, get back an ICD code
     classifier_output = NLC_SERVICE.classify(
-        CLASSIFIER['classifier_id'], inputtext)
+        CLASSIFIER['classifier_id'], inputtext).get_result()
     # get the ICD name based on ICD code
     icd_code, icd_output = _get_ICD_code_info(classifier_output)
     # format results
@@ -75,7 +75,7 @@ def classify_text():
 
 def _create_classifier():
     # fetch all classifiers associated with the NLC instance
-    result = NLC_SERVICE.list_classifiers()
+    result = NLC_SERVICE.list_classifiers().get_result()
     # for the purposes of this demo, we handle only one classifier
     # return the first one found
     if len(result['classifiers']) > 0:
@@ -87,7 +87,7 @@ def _create_classifier():
             classifier = NLC_SERVICE.create_classifier(
                 metadata=metadata,
                 training_data=training_data
-            )
+            ).get_result()
         return classifier
 
 


### PR DESCRIPTION
Add get_results() to calls for NLC classify(), list_classifiers(),
and create_classifier().
Not Done: Changes for iam_apikey.

Closes: #25